### PR TITLE
Update logging for mlperf hpc weak-scaling metrics

### DIFF
--- a/configs/mlperf_hpc.yml
+++ b/configs/mlperf_hpc.yml
@@ -17,6 +17,8 @@ task:
     mlperf_division: closed
     mlperf_status: onprem
     mlperf_platform: SUBMISSION_PLATFORM_PLACEHOLDER
+    mlperf_accelerators_per_node: 8
+    mlperf_accelerators_per_rank: 1
 
     dataset: trajectory_lmdb
     description: "Regressing to energies and forces for DFT trajectories from OCP"

--- a/ocpmodels/trainers/mlperf_forces_trainer.py
+++ b/ocpmodels/trainers/mlperf_forces_trainer.py
@@ -354,6 +354,15 @@ class MLPerfForcesTrainer(BaseTrainer):
             # Start mlperf initialization
             mllogger.start(key=mllog.constants.INIT_START)
 
+            # Weak-scaling HPC metrics
+            accelerators_per_node = self.config["task"]["mlperf_accelerators_per_node"]
+            accelerators_per_rank = self.config["task"]["mlperf_accelerators_per_rank"]
+            num_ranks = distutils.get_world_size()
+            num_nodes = (num_ranks * accelerators_per_rank) // accelerators_per_node
+            mllogger.event(key='number_of_ranks', value=num_ranks)
+            mllogger.event(key='number_of_nodes', value=num_nodes)
+            mllogger.event(key='accelerators_per_node', value=accelerators_per_node)
+
             # Log hyperparameters
             mllogger.event(key=mllog.constants.GLOBAL_BATCH_SIZE,
                            value=self.config["optim"]["batch_size"] * self.config["gpus"])


### PR DESCRIPTION
I added 2 new required things to the config:
- mlperf_accelerators_per_node
- mlperf_accelerators_per_rank

from these I can compute and log the needed parts for mlperf hpc
weak-scaling metrics:
- number_of_ranks (not actually required)
- number_of_nodes (required)
- accelerators_per_node (required)