### PR TITLE
add mlperf logging of the random seed

### DIFF
--- a/ocpmodels/trainers/mlperf_forces_trainer.py
+++ b/ocpmodels/trainers/mlperf_forces_trainer.py
@@ -364,6 +364,7 @@ class MLPerfForcesTrainer(BaseTrainer):
             mllogger.event(key='accelerators_per_node', value=accelerators_per_node)
 
             # Log hyperparameters
+            mllogger.event(key=mllog.constants.SEED, value=self.config["cmd"]["seed"])
             mllogger.event(key=mllog.constants.GLOBAL_BATCH_SIZE,
                            value=self.config["optim"]["batch_size"] * self.config["gpus"])
             mllogger.event(key=mllog.constants.TRAIN_SAMPLES, value=len(self.train_loader.dataset))


### PR DESCRIPTION
The code was previously missing this logging of the random seed setting, which needs to be set either in the config or on the command line. Otherwise it defaults to 0 for every run.